### PR TITLE
tweak the way we deal with whitespace

### DIFF
--- a/commcare_translations.py
+++ b/commcare_translations.py
@@ -10,13 +10,15 @@ def loads(s):
 def load(f):
     messages = {}
     for line in f:
+        # i think this line is wrong, but i don't want to break anything
+        # clayton says there's no \# escaping on the phone
         line = re.split(r'(?<!\\)#', line)[0] # strip comments starting with '#', ignoring '\#'
         line = line.strip()
         if not line: continue
         if not isinstance(line, unicode):
             line = unicode(line, encoding='utf8')
         i = line.index('=')
-        messages[line[:i].strip()] = line[i+1:].strip()
+        messages[line[:i].strip()] = line[i+1:]
     return messages
 
 def load_translations(lang):
@@ -33,5 +35,5 @@ def load_translations(lang):
 def dumps(dct):
     io = StringIO()
     for key,val in sorted(dct.items()):
-        print >> io, u"{key}={val}".format(key=key, val=val).encode('utf8')
+        print >> io, u"{key}={val}".format(key=key.strip(), val=val).encode('utf8')
     return unicode(io.getvalue(), encoding='utf8')

--- a/messages_hin.txt
+++ b/messages_hin.txt
@@ -279,31 +279,6 @@ pregnancy.edd.approaching=निकट
 yes=हाँ
 no=नहीं
 
-#added because the translations were out of sync. Should be cleaned up at some point.
-DebugLog= Debug Log
-PendingReferral=  Rufaa  ambazo  hazijakamilika
-RecentFollowups=  Ufuatiliaji wa Karibuni
-ChooseMgonjwa=  Chagua  Mgonjwa
-Find=  Tafuta
-ReferralFor=  Rufaa  kwa  ajili ya 
-Resolve=  Kamilisha
-Loading=  Inafunguka
-Sending=  Inatumwa
-Language=  Lugha
-Save=  Tunza  
-SaveandExit=  Tunza na  Toka
-Mark=  Chagua
-Unmark=  Usichague
-Clear=  Futa
-Next=  Mbele
-Review=  Pitia  tena 
-Update=  Badilisha         
-Sort=  Panga
-SortBy=  Panga kwa
-Cancel=  Kataa
-
-id=Namba
-
 user.registration.title=उपयोगकर्ता का पंजीकरण
 user.registration.attempt=उपयोगकर्ता का पंजीकरण के लिए सर्वर से संपर्क कर रहा है...
 user.registration.failmessage=उपयोगकर्ता का पंजीकरण पूरा नहीं किया जा सका, सर्वर से संपर्क नहीं किया जा सका. पुनःप्रयास?

--- a/messages_por.txt
+++ b/messages_por.txt
@@ -281,31 +281,6 @@ pregnancy.edd.approaching=Aproximando
 yes=Sim
 no=Não
 
-#added because the translations were out of sync. Should be cleaned up at some point.
-DebugLog= registo de depuração
-PendingReferral=  Rufaa  ambazo  hazijakamilika
-RecentFollowups=  Ufuatiliaji wa Karibuni
-ChooseMgonjwa=  Chagua  Mgonjwa
-Find=  Tafuta
-ReferralFor=  Rufaa  kwa  ajili ya 
-Resolve=  Kamilisha
-Loading=  Inafunguka
-Sending=  Inatumwa
-Language=  Lugha
-Save=  Tunza  
-SaveandExit=  Tunza na  Toka
-Mark=  Chagua
-Unmark=  Usichague
-Clear=  Futa
-Next=  Mbele
-Review=  Pitia  tena 
-Update=  Badilisha         
-Sort=  Panga
-SortBy=  Panga kwa
-Cancel=  Kataa
-
-id=Namba
-
 user.registration.title=Registro de Usuário
 user.registration.attempt=Contactando servidor para registrar ... Usuário
 user.registration.failmessage=O registro do usuário não pôde ser concluído, o servidor não pôde ser contatado. Tentar de novo?

--- a/messages_sw.txt
+++ b/messages_sw.txt
@@ -221,26 +221,26 @@ sending.status.error=Tatizo lisilojulikana katika uwasilishaji
 
 menu.transport=Transport Menu
 
-PendingReferral=  Rufaa  ambazo  hazijakamilika
-RecentFollowups=  Ufuatiliaji wa Karibuni
-ChooseMgonjwa=  Chagua  Mgonjwa
-Find=  Tafuta
-ReferralFor=  Rufaa  kwa  ajili ya 
-Resolve=  Kamilisha
-Loading=  Inafunguka
-Sending=  Inatumwa
-Language=  Lugha
-Save=  Tunza  
-SaveandExit=  Tunza na  Toka
-Mark=  Chagua
-Unmark=  Usichague
-Clear=  Futa
-Next=  Mbele
-Review=  Pitia  tena 
-Update=  Badilisha         
-Sort=  Panga
-SortBy=  Panga kwa
-Cancel=  Kataa
+PendingReferral=Rufaa  ambazo  hazijakamilika
+RecentFollowups=Ufuatiliaji wa Karibuni
+ChooseMgonjwa=Chagua  Mgonjwa
+Find=Tafuta
+ReferralFor=Rufaa  kwa  ajili ya
+Resolve=Kamilisha
+Loading=Inafunguka
+Sending=Inatumwa
+Language=Lugha
+Save=Tunza
+SaveandExit=Tunza na  Toka
+Mark=Chagua
+Unmark=Usichague
+Clear=Futa
+Next=Mbele
+Review=Pitia  tena
+Update=Badilisha
+Sort=Panga
+SortBy=Panga kwa
+Cancel=Kataa
 
 #seems to be used by entity select screen
 date=Tar.


### PR DESCRIPTION
basically, be consistent about what does and doesn't get stripped: in `A=B` format, `A` gets stripped and `B` doesn't (it honors whitespace).
