### PR TITLE
only strip comments at beginning of line

### DIFF
--- a/commcare_translations.py
+++ b/commcare_translations.py
@@ -12,7 +12,7 @@ def load(f):
     for line in f:
         # i think this line is wrong, but i don't want to break anything
         # clayton says there's no \# escaping on the phone
-        line = re.split(r'(?<!\\)#', line)[0] # strip comments starting with '#', ignoring '\#'
+        line = re.split(r'^\s*(?<!\\)#', line)[0] # strip comments starting with '#', ignoring '\#'
         line = line.strip()
         if not line: continue
         if not isinstance(line, unicode):


### PR DESCRIPTION
Any display text after a '#' character was getting treated as a comment e.g. case details headers

http://manage.dimagi.com/default.asp?85307
