### PR TITLE
Remove leading space from two translations

### DIFF
--- a/messages_en-2.txt
+++ b/messages_en-2.txt
@@ -243,7 +243,7 @@ polish.TextField.charactersKey6=mno6
 polish.TextField.charactersKey7=pqrs7
 polish.TextField.charactersKey8=tuv8
 polish.TextField.charactersKey9=wxyz9
-polish.TextField.charactersKey0= 0
+polish.TextField.charactersKey0=0
 
 #User registration
 menu.send.later=Send Later
@@ -451,7 +451,7 @@ updates.checking=Checking for updates...
 
 verify.title=CommCare Resource Verification
 verify.checking=Verifying Resources
-verify.progress = Verifying resources. ${0} resources verified of ${1} total
+verify.progress=Verifying resources. ${0} resources verified of ${1} total
 
 modules.m0=pregenancy
 


### PR DESCRIPTION
I'm working on bulk ui translations. When a string is written to an excel file, any leading spaces are truncated. I need to compare strings from the excel upload to the strings that were put in the download. Removing the spaces here will keep the hq code cleaner as I won't need to call `lstrip(" ")`.
