### PR TITLE
remove leading spaces in messages_en-2.txt

### DIFF
--- a/messages_en-2.txt
+++ b/messages_en-2.txt
@@ -245,7 +245,7 @@ polish.TextField.charactersKey6=mno6
 polish.TextField.charactersKey7=pqrs7
 polish.TextField.charactersKey8=tuv8
 polish.TextField.charactersKey9=wxyz9
-polish.TextField.charactersKey0= 0
+polish.TextField.charactersKey0=0
 
 #User registration
 menu.send.later=Send Later
@@ -461,7 +461,7 @@ updates.keep.trying=Keep trying if connection is interrupted
 
 verify.title=CommCare Resource Verification
 verify.checking=Verifying Resources
-verify.progress = Verifying resources. ${0} resources verified of ${1} total
+verify.progress=Verifying resources. ${0} resources verified of ${1} total
 
 install.barcode.top=Welcome to CommCare!
 install.barcode.bottom=Please choose an installation method below


### PR DESCRIPTION
@amstone326 looks like the script missed a couple spaces. Feels better to have that right in this file than it does to strip them later