### PR TITLE
Option to use latest available historical translations file

### DIFF
--- a/commcare_translations.py
+++ b/commcare_translations.py
@@ -1,4 +1,5 @@
 from distutils.version import StrictVersion
+from os import listdir
 from os.path import join, normpath
 import re
 from StringIO import StringIO
@@ -36,7 +37,17 @@ def load_translations(lang, version=1, commcare_version=None):
         return {}
 
     paths_to_try = []
-    if commcare_version:
+    if commcare_version == 'latest':
+        files = listdir(normpath(join(__file__, "../historical-translations-by-version/")))
+        if len(files):
+            files.sort()
+            files.reverse()
+            paths_to_try.append(
+                '../historical-translations-by-version/{file}'
+                .format(file=files[0])
+            )
+            commcare_version = None
+    elif commcare_version:
         try:
             commcare_version = StrictVersion(commcare_version)
         except ValueError:


### PR DESCRIPTION
Because we now [support historical translations](https://github.com/dimagi/commcare-hq/pull/14748), the bulk ui translations tests now [depend on knowing the current version of CommCare](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/tests/test_bulk_ui_translation.py#L21). Rather than tweak the mobile deploy scripts to update that test, I added code to pull the latest available translations file rather than a specific version.

@dannyroberts does this seem reasonable?
cc @esoergel 