### PR TITLE
Fix translation spanning multiple lines

### DIFF
--- a/historical-translations-by-version/2.43-messages_en-2.txt
+++ b/historical-translations-by-version/2.43-messages_en-2.txt
@@ -837,21 +837,7 @@ quarantine.reason.unknown=Reason for quarantine unknown
 
 # *** strings.xml ***
 
-odk_about_dialog=${0}\n\n
-_Copyright 2016, Dimagi inc, All rights reserved_ \n\n
-
----------------- \n\n
-__Acknowledgements:__ \n\n
-${0}
-Some images in CommCare are graciously used under Creative Commons Licensing from thenounproject.com collection:\n\n
-* “Door” symbol by Tak Imoto \n
-* “Pencil” symbol by Creologica \n
-* “Notebook” symbol by Carlo \n
-* “Antenna” symbol by Dima \n
-* “Map Marker” symbol by P.J. Onori \n
-* "List" by Landan Lloyd \n
-* broken screen by Sam Martin from the Noun Project \n\n
-
+odk_about_dialog=${0}\n\n_Copyright 2016, Dimagi inc, All rights reserved_ \n\n---------------- \n\n__Acknowledgements:__ \n\n${0}Some images in CommCare are graciously used under Creative Commons Licensing from thenounproject.com collection:\n\n* “Door” symbol by Tak Imoto \n* “Pencil” symbol by Creologica \n* “Notebook” symbol by Carlo \n* “Antenna” symbol by Dima \n* “Map Marker” symbol by P.J. Onori \n* "List" by Landan Lloyd \n* broken screen by Sam Martin from the Noun Project \n\n
 
 odk_about_cc=About CommCare
 odk_accept_location=Record Location


### PR DESCRIPTION
@sravfeyn this fixes the issue you raised in https://github.com/dimagi/commcare-hq/pull/20479, thank you for pointing it out! I've also changed the origin string in the `commcare-android` repo so that it doesn't happen again in the future: https://github.com/dimagi/commcare-android/pull/1999. 