### PR TITLE
remove empty space causing mismatch in translations when uploading bulk translations

### DIFF
--- a/historical-translations-by-version/2.23-messages_en-2.txt
+++ b/historical-translations-by-version/2.23-messages_en-2.txt
@@ -245,7 +245,7 @@ polish.TextField.charactersKey6=mno6
 polish.TextField.charactersKey7=pqrs7
 polish.TextField.charactersKey8=tuv8
 polish.TextField.charactersKey9=wxyz9
-polish.TextField.charactersKey0= 0
+polish.TextField.charactersKey0=0
 
 #User registration
 menu.send.later=Send Later
@@ -461,7 +461,7 @@ updates.keep.trying=Keep trying if connection is interrupted
 
 verify.title=CommCare Resource Verification
 verify.checking=Verifying Resources
-verify.progress = Verifying resources. ${0} resources verified of ${1} total
+verify.progress=Verifying resources. ${0} resources verified of ${1} total
 
 install.barcode.top=Welcome to CommCare!
 install.barcode.bottom=Please choose an installation method below


### PR DESCRIPTION
Noticed two places where empty space was causing mismatch. The default translation was " 0" but when excel was uploaded back it was parsed as "0", hence resulting in a mismatch and getting added to app.translations as "0". Looks like a miss when those files were added because for other versions its present correctly without space.