### PR TITLE
removed case.search.title

### DIFF
--- a/historical-translations-by-version/2.52-messages_en-2.txt
+++ b/historical-translations-by-version/2.52-messages_en-2.txt
@@ -847,7 +847,6 @@ permission.location.denial.message=CommCare doesn't have the permission to use l
 
 custom.acknowledgement=
 case.error.self.index=Case '${0}' cannot index itself. In order to login you must change the case on the server.
-case.search.title=Case Claim
 
 intent.barcode.get=Get Barcode
 intent.barcode.update=Update Barcode


### PR DESCRIPTION
`case.search.title` translation is being replaced by the new `title_label` attribute outlined in this [pull request](https://github.com/dimagi/commcare-hq/pull/32149l). This PR removes `case.search.title` from the current translation file. 