### PR TITLE
Update 2.53-messages_en-2.txt

### DIFF
--- a/historical-translations-by-version/2.53-messages_en-2.txt
+++ b/historical-translations-by-version/2.53-messages_en-2.txt
@@ -459,6 +459,8 @@ recording.prompt.with.file.chooser=Record or choose sound below
 recording.prompt.without.file.chooser=Record sound below
 recording.custom=Recorded Sound
 
+upload.clear.title=Clear
+
 callout.failure.dialer=Device is not currently configured to make telephone calls
 callout.failure.sms=SMS app not found
 callout.missing=No application found for action: ${0}


### PR DESCRIPTION
Part of https://dimagi-dev.atlassian.net/browse/USH-3867 , adds a new translation string for the "Clear" button for upload questions in Web Apps.

There's already `button.clear.title` to control the "Clear" button for radio buttons, but I think it's reasonable to want a different translation for clearing attachments.

I think this is the right thing to do based on https://github.com/dimagi/commcare-translations/pull/70 - add the translation to the current prod version of CommCare.